### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -177,7 +177,7 @@ class FormBuilder extends Plugin
      */
     private function _addTwigExtensions()
     {
-        Craft::$app->view->twig->addExtension(new Extensions);
+        Craft::$app->view->registerTwigExtension(new Extensions);
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.