### PR TITLE
Take table prefix into account

### DIFF
--- a/src/plugin/Table.php
+++ b/src/plugin/Table.php
@@ -4,6 +4,6 @@ namespace roundhouse\formbuilder\plugin;
 
 abstract class Table
 {
-    const ENTRIES = 'formbuilder_entries';
-    const FORMS = 'formbuilder_forms';
+    const ENTRIES = '{{%formbuilder_entries}}';
+    const FORMS = '{{%formbuilder_forms}}';
 }


### PR DESCRIPTION
Fixes #18 - Without this, the plugin breaks if the user has chosen to use a table prefix